### PR TITLE
Fix Resources in 4.2

### DIFF
--- a/code/Icon.php
+++ b/code/Icon.php
@@ -78,7 +78,7 @@ class Icon extends DBField {
 		}
 		
 		// figure out the full system location for the file
-		$filePath = BASE_PATH.$url;
+		$filePath = BASE_PATH.str_replace('/resources', '', $url);
 		if (!file_exists($filePath)){
 			return false;
 		}


### PR DESCRIPTION
SVG method fails to follow symlink. Change link directly to the file.